### PR TITLE
Refactor namespaces and folder structure

### DIFF
--- a/mossman/.cproject
+++ b/mossman/.cproject
@@ -16,65 +16,54 @@
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug,org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.exe.debug.408162626" name="Debug" parent="cdt.managedbuild.config.gnu.exe.debug">
 					<folderInfo id="cdt.managedbuild.config.gnu.exe.debug.408162626." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.exe.debug.780258227" name="Linux GCC" superClass="cdt.managedbuild.toolchain.gnu.exe.debug">
-							<targetPlatform id="cdt.managedbuild.target.gnu.platform.exe.debug.1803915647" name="Debug Platform" superClass="cdt.managedbuild.target.gnu.platform.exe.debug"/>
-							<builder buildPath="${workspace_loc:/SfmlTest}/Debug" id="cdt.managedbuild.target.gnu.builder.exe.debug.990898013" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.exe.debug"/>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.base.1848576917" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.exe.debug.2092976390" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.exe.debug">
-								<option id="gnu.cpp.compiler.exe.debug.option.optimization.level.5262700" name="Optimization Level" superClass="gnu.cpp.compiler.exe.debug.option.optimization.level" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.exe.debug.option.debugging.level.670010895" name="Debug Level" superClass="gnu.cpp.compiler.exe.debug.option.debugging.level" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.1583306821" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.2002252866" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" valueType="definedSymbols">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.base.512020314" name="Linux GCC" superClass="cdt.managedbuild.toolchain.gnu.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.target.gnu.platform.base.2125072499" name="Debug Platform" osList="linux,hpux,aix,qnx" superClass="cdt.managedbuild.target.gnu.platform.base"/>
+							<builder buildPath="${workspace_loc:/mossman}/Debug" id="cdt.managedbuild.target.gnu.builder.base.1486673011" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="false" superClass="cdt.managedbuild.target.gnu.builder.base">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name="Debug"/>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name="Release"/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.archiver.base.145571855" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base"/>
+							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.base.1194668716" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.base">
+								<option id="gnu.cpp.compiler.option.preprocessor.def.360794923" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__GXX_EXPERIMENTAL_CXX0X__"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.include.paths.1769637211" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="src"/>
-									<listOptionValue builtIn="false" value=""/>
+								<option id="gnu.cpp.compiler.option.optimization.level.1809394310" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.2119922045" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.include.paths.2092943428" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src}&quot;"/>
 								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1167623870" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.1444753811" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1912369325" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.exe.debug.1944339552" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.exe.debug">
-								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.exe.debug.option.optimization.level.1237582119" name="Optimization Level" superClass="gnu.c.compiler.exe.debug.option.optimization.level" valueType="enumerated"/>
-								<option id="gnu.c.compiler.exe.debug.option.debugging.level.274347456" name="Debug Level" superClass="gnu.c.compiler.exe.debug.option.debugging.level" value="gnu.c.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.preprocessor.def.symbols.326385684" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols"/>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.758139659" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							<tool id="cdt.managedbuild.tool.gnu.c.compiler.base.1153639639" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.base">
+								<option id="gnu.c.compiler.option.include.paths.1302829856" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" valueType="includePath"/>
+								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.1745630930" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.1081210884" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.1694485382" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__GXX_EXPERIMENTAL_CXX0X__"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1467705969" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.linker.exe.debug.725403413" name="GCC C Linker" superClass="cdt.managedbuild.tool.gnu.c.linker.exe.debug"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.linker.exe.debug.1819943779" name="GCC C++ Linker" superClass="cdt.managedbuild.tool.gnu.cpp.linker.exe.debug">
-								<option id="gnu.cpp.link.option.libs.934202836" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs" valueType="libs">
+							<tool id="cdt.managedbuild.tool.gnu.c.linker.base.583579780" name="GCC C Linker" superClass="cdt.managedbuild.tool.gnu.c.linker.base"/>
+							<tool id="cdt.managedbuild.tool.gnu.cpp.linker.base.373044768" name="GCC C++ Linker" superClass="cdt.managedbuild.tool.gnu.cpp.linker.base">
+								<option id="gnu.cpp.link.option.libs.940004495" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs" valueType="libs">
 									<listOptionValue builtIn="false" value="sfml-graphics"/>
-									<listOptionValue builtIn="false" value=""/>
-									<listOptionValue builtIn="false" value="sfml-system"/>
 									<listOptionValue builtIn="false" value="sfml-window"/>
+									<listOptionValue builtIn="false" value="sfml-system"/>
 								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.1671519512" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+								<option id="gnu.cpp.link.option.paths.299119948" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths" valueType="libPaths">
+									<listOptionValue builtIn="false" value="/usr/lib64"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.880129308" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
 								</inputType>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.exe.debug.226915674" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.exe.debug">
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1294774922" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
-							</tool>
-						</toolChain>
-					</folderInfo>
-					<folderInfo id="cdt.managedbuild.config.gnu.exe.debug.408162626.1509581600" name="/" resourcePath="src">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.exe.debug.949940865" name="Linux GCC" superClass="cdt.managedbuild.toolchain.gnu.exe.debug" unusedChildren="">
-							<targetPlatform id="cdt.managedbuild.target.gnu.platform.exe.debug" name="Debug Platform" superClass="cdt.managedbuild.target.gnu.platform.exe.debug"/>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.base.1183410560" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base.1848576917"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.exe.debug.1993182259" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.exe.debug.2092976390">
-								<option id="gnu.cpp.compiler.option.include.paths.1555471473" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="src"/>
-									<listOptionValue builtIn="false" value="src/Core"/>
-								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1327831182" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
-							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.exe.debug.2051941260" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.exe.debug.1944339552">
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1066744407" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
-							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.linker.exe.debug.907265196" name="GCC C Linker" superClass="cdt.managedbuild.tool.gnu.c.linker.exe.debug.725403413"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.linker.exe.debug.50720516" name="GCC C++ Linker" superClass="cdt.managedbuild.tool.gnu.cpp.linker.exe.debug.1819943779"/>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.exe.debug.247253627" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.exe.debug.226915674">
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.23274345" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							<tool id="cdt.managedbuild.tool.gnu.assembler.base.70889850" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.base">
+								<option id="gnu.both.asm.option.include.paths.277141046" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1363128418" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
 						</toolChain>
 					</folderInfo>
@@ -145,21 +134,35 @@
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="SfmlTest.cdt.managedbuild.target.gnu.exe.589608470" name="Executable" projectType="cdt.managedbuild.target.gnu.exe"/>
 	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Release">
+			<resource resourceType="PROJECT" workspacePath="/mossman"/>
+		</configuration>
+		<configuration configurationName="Debug">
+			<resource resourceType="PROJECT" workspacePath="/mossman"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 	<storageModule moduleId="scannerConfiguration">
 		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.release.1653786408;cdt.managedbuild.config.gnu.exe.release.1653786408.;cdt.managedbuild.tool.gnu.c.compiler.exe.release.2124716617;cdt.managedbuild.tool.gnu.c.compiler.input.2004893846">
-			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.debug.408162626;cdt.managedbuild.config.gnu.exe.debug.408162626.;cdt.managedbuild.tool.gnu.c.compiler.exe.debug.1944339552;cdt.managedbuild.tool.gnu.c.compiler.input.758139659">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.release.1653786408;cdt.managedbuild.config.gnu.exe.release.1653786408.;cdt.managedbuild.tool.gnu.cpp.compiler.exe.release.1650089268;cdt.managedbuild.tool.gnu.cpp.compiler.input.338097628">
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.release.1653786408;cdt.managedbuild.config.gnu.exe.release.1653786408.;cdt.managedbuild.tool.gnu.c.compiler.exe.release.2124716617;cdt.managedbuild.tool.gnu.c.compiler.input.2004893846">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.debug.408162626;cdt.managedbuild.config.gnu.exe.debug.408162626.;cdt.managedbuild.tool.gnu.cpp.compiler.exe.debug.2092976390;cdt.managedbuild.tool.gnu.cpp.compiler.input.1167623870">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.debug.408162626;cdt.managedbuild.config.gnu.exe.debug.408162626.;cdt.managedbuild.tool.gnu.c.compiler.base.1153639639;cdt.managedbuild.tool.gnu.c.compiler.input.1467705969">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.release.1653786408;cdt.managedbuild.config.gnu.exe.release.1653786408.;cdt.managedbuild.tool.gnu.cpp.compiler.exe.release.1650089268;cdt.managedbuild.tool.gnu.cpp.compiler.input.338097628">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.exe.debug.408162626;cdt.managedbuild.config.gnu.exe.debug.408162626.;cdt.managedbuild.tool.gnu.cpp.compiler.base.1194668716;cdt.managedbuild.tool.gnu.cpp.compiler.input.1912369325">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
 	</storageModule>
-	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
-	<storageModule moduleId="refreshScope"/>
 </cproject>

--- a/mossman/.settings/org.eclipse.ltk.core.refactoring.prefs
+++ b/mossman/.settings/org.eclipse.ltk.core.refactoring.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.ltk.core.refactoring.enable.project.refactoring.history=false

--- a/mossman/src/core/Application.cpp
+++ b/mossman/src/core/Application.cpp
@@ -6,10 +6,13 @@
  */
 
 #include "Application.h"
-#include "Scenes/Julia/JuliaScene.h"
+
 #include <memory>
 
-namespace Mossman {
+#include "scenes/julia/JuliaSceneSFMLRenderer.h"
+#include "scenes/JuliaScene.h"
+
+namespace mossman {
 
 Application::Application() : mWindow(nullptr), mQuitSignaled(false) {
 	// TODO Auto-generated constructor stub
@@ -21,15 +24,15 @@ Application::~Application() {
 }
 
 void Application::init() {
-	using namespace Mossman::Scenes::Julia;
-	mWindow = std::make_shared<sf::RenderWindow>(sf::VideoMode(1280, 1024), "SFML works!");
+	using namespace mossman::scenes;
+	mWindow = std::make_shared<sf::RenderWindow>(sf::VideoMode(1280, 1024), "mossman");
 	mWindow->setVerticalSyncEnabled(true);
 
 	JuliaScene* juliaScene = new JuliaScene();
 
-	JuliaSceneSFMLRenderer* juliaSceneRenderer = new JuliaSceneSFMLRenderer(mWindow, juliaScene);
+	julia::JuliaSceneSFMLRenderer* juliaSceneRenderer = new julia::JuliaSceneSFMLRenderer(mWindow, juliaScene);
 
-	int i = mSceneManager.addScene(juliaScene, juliaSceneRenderer);
+	mSceneManager.addScene(juliaScene, juliaSceneRenderer);
 }
 
 void Application::update(double dt) {
@@ -57,4 +60,4 @@ std::shared_ptr<sf::RenderWindow> Application::getRenderContext() const {
 	return mWindow;
 }
 
-} /* namespace Mossman */
+} /* namespace mossman */

--- a/mossman/src/core/Application.h
+++ b/mossman/src/core/Application.h
@@ -11,11 +11,9 @@
 #include <SFML/Graphics.hpp>
 #include <memory>
 
-#include "Core/SceneManager.h"
+#include "SceneManager.h"
 
-namespace Mossman {
-
-using namespace Mossman::Core;
+namespace mossman {
 
 class Application {
 public:
@@ -42,6 +40,6 @@ private:
 	bool mQuitSignaled;
 };
 
-} /* namespace Mossman */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_APPLICATION_H_ */

--- a/mossman/src/core/Renderer.h
+++ b/mossman/src/core/Renderer.h
@@ -8,8 +8,7 @@
 #ifndef MOSSMAN_SRC_GRAPHICS_RENDERER_H_
 #define MOSSMAN_SRC_GRAPHICS_RENDERER_H_
 
-namespace Mossman {
-namespace Graphics {
+namespace mossman {
 
 class Renderer {
 public:
@@ -18,7 +17,6 @@ public:
 	virtual void render() = 0;
 };
 
-} /* namespace Graphics */
-} /* namespace Mossman */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_GRAPHICS_RENDERER_H_ */

--- a/mossman/src/core/Scene.cpp
+++ b/mossman/src/core/Scene.cpp
@@ -7,8 +7,7 @@
 
 #include "Scene.h"
 
-namespace Mossman {
-namespace Core {
+namespace mossman {
 
 Scene::Scene() {
 	// TODO Auto-generated constructor stub
@@ -19,5 +18,4 @@ Scene::~Scene() {
 	// TODO Auto-generated destructor stub
 }
 
-} /* namespace Core */
-} /* namespace Mossman */
+} /* namespace mossman */

--- a/mossman/src/core/Scene.h
+++ b/mossman/src/core/Scene.h
@@ -8,10 +8,7 @@
 #ifndef MOSSMAN_SRC_CORE_SCENE_H_
 #define MOSSMAN_SRC_CORE_SCENE_H_
 
-#include "../Application.h"
-
-namespace Mossman {
-namespace Core {
+namespace mossman {
 
 class Scene {
 public:
@@ -23,7 +20,6 @@ public:
 	virtual void deactivated() = 0;
 };
 
-} /* namespace Core */
-} /* namespace Mossman */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_CORE_SCENE_H_ */

--- a/mossman/src/core/SceneManager.cpp
+++ b/mossman/src/core/SceneManager.cpp
@@ -8,8 +8,7 @@
 #include "SceneManager.h"
 #include "Scene.h"
 
-namespace Mossman {
-namespace Core {
+namespace mossman {
 
 SceneManager::SceneManager() : mActiveScene(nullptr), mActiveRenderer(nullptr) {
 	// TODO Auto-generated constructor stub
@@ -59,5 +58,4 @@ void SceneManager::renderActiveScene() {
 	mActiveRenderer->render();
 }
 
-} /* namespace Core */
-} /* namespace Mossman */
+} /* namespace mossman */

--- a/mossman/src/core/SceneManager.h
+++ b/mossman/src/core/SceneManager.h
@@ -10,14 +10,12 @@
 
 #include <vector>
 #include <memory>
-#include "../Graphics/SceneRenderer.h"
-#include "../Graphics/Renderer.h"
 
-namespace Mossman {
-namespace Core {
+#include "Renderer.h"
+
+namespace mossman {
 
 class Scene;
-using namespace Mossman::Graphics;
 
 class SceneManager {
 public:
@@ -38,7 +36,6 @@ private:
 	Renderer* mActiveRenderer;
 };
 
-} /* namespace Core */
-} /* namespace Mossman */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_CORE_SCENEMANAGER_H_ */

--- a/mossman/src/core/SceneRenderer.h
+++ b/mossman/src/core/SceneRenderer.h
@@ -10,8 +10,7 @@
 
 #include "Renderer.h"
 
-namespace Mossman {
-namespace Graphics {
+namespace mossman {
 
 template<class TScene>
 class SceneRenderer : public Renderer {
@@ -25,7 +24,6 @@ protected:
 	TScene* mScene;
 };
 
-} /* namespace Graphics */
-} /* namespace Mossman */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_GRAPHICS_SCENERENDERER_H_ */

--- a/mossman/src/graphics/SFMLRenderer.cpp
+++ b/mossman/src/graphics/SFMLRenderer.cpp
@@ -5,12 +5,12 @@
  *      Author: ville
  */
 
+#include "SFMLRenderer.h"
 #include <SFML/Graphics.hpp>
 #include <memory>
-#include "SFMLRenderer.h"
 
-namespace Mossman {
-namespace Graphics {
+namespace mossman {
+namespace graphics {
 
 SFMLRenderer::SFMLRenderer(std::shared_ptr<sf::RenderWindow> context) : mContext(context) {
 
@@ -20,5 +20,5 @@ SFMLRenderer::~SFMLRenderer() {
 	// TODO Auto-generated destructor stub
 }
 
-} /* namespace Graphics */
-} /* namespace Mossman */
+} /* namespace graphics */
+} /* namespace mossman */

--- a/mossman/src/graphics/SFMLRenderer.h
+++ b/mossman/src/graphics/SFMLRenderer.h
@@ -11,8 +11,8 @@
 #include <memory>
 #include <SFML/Graphics.hpp>
 
-namespace Mossman {
-namespace Graphics {
+namespace mossman {
+namespace graphics {
 
 class SFMLRenderer {
 public:
@@ -22,7 +22,7 @@ protected:
 	std::shared_ptr<sf::RenderWindow> mContext;
 };
 
-} /* namespace Graphics */
-} /* namespace Mossman */
+} /* namespace graphics */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_GRAPHICS_SFMLRENDERER_H_ */

--- a/mossman/src/main.cpp
+++ b/mossman/src/main.cpp
@@ -6,13 +6,15 @@
  */
 
 #include <chrono>
-#include "Application.h"
+#include "core/Application.h"
+
+using namespace mossman;
 
 int main()
 {
 	using namespace std::chrono;
 
-	Mossman::Application app;
+	mossman::Application app;
 	app.init();
 
 	auto currentTime = high_resolution_clock::now();

--- a/mossman/src/scenes/JuliaScene.cpp
+++ b/mossman/src/scenes/JuliaScene.cpp
@@ -8,9 +8,8 @@
 #include "JuliaScene.h"
 #include <iostream>
 
-namespace Mossman {
-namespace Scenes {
-namespace Julia {
+namespace mossman {
+namespace scenes {
 
 JuliaScene::JuliaScene() {
 
@@ -32,6 +31,5 @@ void JuliaScene::deactivated() {
 
 }
 
-} /* namespace Julia */
-} /* namespace Scenes */
-} /* namespace Mossman */
+} /* namespace scenes */
+} /* namespace mossman */

--- a/mossman/src/scenes/JuliaScene.h
+++ b/mossman/src/scenes/JuliaScene.h
@@ -8,14 +8,10 @@
 #ifndef SCENES_JULIA_JULIASCENE_H_
 #define SCENES_JULIA_JULIASCENE_
 
-#include "../../Core/Scene.h"
-#include "JuliaSceneSFMLRenderer.h"
+#include "core/Scene.h"
 
-namespace Mossman {
-namespace Scenes {
-namespace Julia {
-
-using namespace Mossman::Core;
+namespace mossman {
+namespace scenes {
 
 class JuliaScene : public Scene {
 public:
@@ -27,8 +23,7 @@ public:
 	virtual void deactivated();
 };
 
-} /* namespace Julia */
-} /* namespace Scenes */
-} /* namespace Mossman */
+} /* namespace scenes */
+} /* namespace mossman */
 
 #endif /* SCENES_JULIA_JULIASCENE_H_ */

--- a/mossman/src/scenes/julia/JuliaSceneSFMLRenderer.cpp
+++ b/mossman/src/scenes/julia/JuliaSceneSFMLRenderer.cpp
@@ -8,12 +8,12 @@
 #include "JuliaSceneSFMLRenderer.h"
 #include <iostream>
 
-namespace Mossman {
-namespace Scenes {
-namespace Julia {
+namespace mossman {
+namespace scenes {
+namespace julia {
 
 JuliaSceneSFMLRenderer::JuliaSceneSFMLRenderer(std::shared_ptr<sf::RenderWindow> context, JuliaScene* scene) :
-		SFMLRenderer(context),
+		graphics::SFMLRenderer(context),
 		SceneRenderer<JuliaScene>(scene)
 {
 	if(!mShader.loadFromFile("res/scenes/julia/julia.frag", sf::Shader::Fragment)) {
@@ -62,6 +62,6 @@ void JuliaSceneSFMLRenderer::render() {
 	std::cout << "OK" << std::endl;
 }
 
-} /* namespace Julia */
-} /* namespace Scenes */
-} /* namespace Mossman */
+} /* namespace julia */
+} /* namespace scenes */
+} /* namespace mossman */

--- a/mossman/src/scenes/julia/JuliaSceneSFMLRenderer.h
+++ b/mossman/src/scenes/julia/JuliaSceneSFMLRenderer.h
@@ -11,18 +11,17 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/OpenGL.hpp>
 
-#include "../../Graphics/SFMLRenderer.h"
-#include "../../Graphics/SceneRenderer.h"
+#include "graphics/SFMLRenderer.h"
+#include "core/SceneRenderer.h"
 
-namespace Mossman {
-namespace Scenes {
-namespace Julia {
+namespace mossman {
+namespace scenes {
 
 class JuliaScene;
 
-using namespace Mossman::Graphics;
+namespace julia {
 
-class JuliaSceneSFMLRenderer : public SFMLRenderer, public SceneRenderer<JuliaScene> {
+class JuliaSceneSFMLRenderer : public graphics::SFMLRenderer, public SceneRenderer<JuliaScene> {
 public:
 	JuliaSceneSFMLRenderer(std::shared_ptr<sf::RenderWindow> context, JuliaScene* scene);
 	virtual ~JuliaSceneSFMLRenderer();
@@ -35,8 +34,8 @@ private:
 	float mShrink;
 };
 
-} /* namespace Julia */
-} /* namespace Scenes */
-} /* namespace Mossman */
+} /* namespace julia */
+} /* namespace scenes */
+} /* namespace mossman */
 
 #endif /* MOSSMAN_SRC_SCENES_JULIA_JULIASCENESFMLRENDERER_H_ */


### PR DESCRIPTION
Move things around to more clearly separate concerns.

The idea is to: 
- have a `core` folder for all things central to the domain of the application, including interfaces for rendering
- put graphics-specific stuff under `graphics`
- put different scenes in `scenes`, with only the main file directly under `scenes` and all implementation details in a separate namespace and directory, e.g. `src/scenes/julia` and `mossman::scenes::julia`
